### PR TITLE
[*] Fix error no module named apps.project. R: Typo in the app name. …

### DIFF
--- a/src/backend/config/settings/base.py
+++ b/src/backend/config/settings/base.py
@@ -39,7 +39,7 @@ THIRD_PARTY_APPS = [
 LOCAL_APPS: list = [
     "apps.general",
     "apps.users",
-    "apps.project",
+    "apps.projects",
     "apps.profile",
 ]
 


### PR DESCRIPTION
- пофиксил название приложения projects в настройках проекта.